### PR TITLE
Suport RFC6749 release version of OAuth2

### DIFF
--- a/src/oauthentic/core.clj
+++ b/src/oauthentic/core.clj
@@ -70,18 +70,18 @@
 
 (defmulti token-request "Create a token request map" grant-type)
 
-;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.1.3
+;; http://tools.ietf.org/html/rfc6749#section-4.1.3
 (defmethod token-request :authorization-code
   [params]
   { :accept :json :as :json
     :form-params (-> params
                     (assoc :redirect_uri (:redirect-uri params))
-                    (select-keys [:code :scope :redirect_uri])
+                    (select-keys [:code :scope :client-id :redirect_uri])
                     (assoc :grant_type "authorization_code"))
     :basic-auth [(:client-id params) (:client-secret params)]
     :insecure? (allow-insecure? params)})
 
-;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.4
+;; http://tools.ietf.org/html/rfc6749#section-4.4
 (defmethod token-request :client-credentials
   [params]
   { :accept :json :as :json
@@ -91,7 +91,7 @@
     :basic-auth [(:client-id params) (:client-secret params)]
     :insecure? (allow-insecure? params)})
 
-;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.3
+;; http://tools.ietf.org/html/rfc6749#section-4.3
 (defmethod token-request :password
   [params]
   { :accept :json :as :json
@@ -102,7 +102,7 @@
     :basic-auth [(:client-id params) (:client-secret params)]
     :insecure? (allow-insecure? params)})
 
-;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-6
+;; http://tools.ietf.org/html/rfc6749#section-6
 (defmethod token-request :refresh-token
   [params]
   { :accept :json :as :json

--- a/src/oauthentic/core.clj
+++ b/src/oauthentic/core.clj
@@ -76,7 +76,8 @@
   { :accept :json :as :json
     :form-params (-> params
                     (assoc :redirect_uri (:redirect-uri params))
-                    (select-keys [:code :scope :client-id :redirect_uri])
+                    (assoc :client_id (:client-id params))
+                    (select-keys [:code :scope :client_id :redirect_uri])
                     (assoc :grant_type "authorization_code"))
     :basic-auth [(:client-id params) (:client-secret params)]
     :insecure? (allow-insecure? params)})

--- a/src/oauthentic/core.clj
+++ b/src/oauthentic/core.clj
@@ -77,7 +77,8 @@
     :form-params (-> params
                     (assoc :redirect_uri (:redirect-uri params))
                     (assoc :client_id (:client-id params))
-                    (select-keys [:code :scope :client_id :redirect_uri])
+                    (assoc :client_secret (:client-secret params))
+                    (select-keys [:code :scope :client_id :client_secret :redirect_uri])
                     (assoc :grant_type "authorization_code"))
     :basic-auth [(:client-id params) (:client-secret params)]
     :insecure? (allow-insecure? params)})

--- a/src/oauthentic/core.clj
+++ b/src/oauthentic/core.clj
@@ -62,6 +62,12 @@
     (:username params) :password
     :else :client-credentials))
 
+(defn allow-insecure?
+  "Allow use of insecure SSL, such as self-signed certs"
+  [params]
+  (if (nil? (:insecure? params)) false (:insecure? params))
+  )
+
 (defmulti token-request "Create a token request map" grant-type)
 
 ;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.1.3
@@ -72,7 +78,8 @@
                     (assoc :redirect_uri (:redirect-uri params))
                     (select-keys [:code :scope :redirect_uri])
                     (assoc :grant_type "authorization_code"))
-    :basic-auth [(:client-id params) (:client-secret params)]})
+    :basic-auth [(:client-id params) (:client-secret params)]
+    :insecure? (allow-insecure? params)})
 
 ;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.4
 (defmethod token-request :client-credentials
@@ -81,7 +88,8 @@
     :form-params (-> params
                     (select-keys [:scope])
                     (assoc :grant_type "client_credentials"))
-    :basic-auth [(:client-id params) (:client-secret params)]})
+    :basic-auth [(:client-id params) (:client-secret params)]
+    :insecure? (allow-insecure? params)})
 
 ;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.3
 (defmethod token-request :password
@@ -91,7 +99,8 @@
                     (select-keys [:username :password :scope])
                     (assoc :grant_type "password"))
 
-    :basic-auth [(:client-id params) (:client-secret params)]})
+    :basic-auth [(:client-id params) (:client-secret params)]
+    :insecure? (allow-insecure? params)})
 
 ;; http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-6
 (defmethod token-request :refresh-token
@@ -100,7 +109,8 @@
     :form-params (-> params
                      (select-keys [:scope])
                      (assoc :refresh_token (:refresh-token params) :grant_type "refresh_token"))
-    :basic-auth [(:client-id params) (:client-secret params)]})
+    :basic-auth [(:client-id params) (:client-secret params)]
+    :insecure? (allow-insecure? params)})
 
 (defmulti fetch-token "Fetch an oauth token from server" keyword-or-class)
 

--- a/test/oauthentic/test/core.clj
+++ b/test/oauthentic/test/core.clj
@@ -45,7 +45,7 @@
     {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client_id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
@@ -60,7 +60,7 @@
     {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" :insecure? true })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client_id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback" :insecure? true})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }

--- a/test/oauthentic/test/core.clj
+++ b/test/oauthentic/test/core.clj
@@ -39,18 +39,33 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "client_credentials", :scope "basic"}, :basic-auth ["CLIENT-ID" "SECRET"]}
+    {:accept :json, :as :json, :form-params { :grant_type "client_credentials", :scope "basic"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"]}
+    {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"] }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"] }
+    {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
     (token-request { :refresh-token "REFRESH" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic"})))
   )
+
+(deftest insecure-token-requests
+  (is (=
+    {:accept :json, :as :json, :form-params { :grant_type "client_credentials", :scope "basic"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true}
+    (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :insecure? true})))
+  (is (=
+    {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true}
+    (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" :insecure? true })))
+  (is (=
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
+    (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback" :insecure? true})))
+  (is (=
+    {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
+    (token-request { :refresh-token "REFRESH" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :insecure? true})))
+)
 
 (deftest fetch-oauth-tokens-for-auth-code
   (t/reset-token-store!)

--- a/test/oauthentic/test/core.clj
+++ b/test/oauthentic/test/core.clj
@@ -45,7 +45,7 @@
     {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
@@ -60,7 +60,7 @@
     {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" :insecure? true })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback" :insecure? true})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }

--- a/test/oauthentic/test/core.clj
+++ b/test/oauthentic/test/core.clj
@@ -45,7 +45,7 @@
     {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client_id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client_id "CLIENT-ID" :client_secret "SECRET" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? false }
@@ -60,7 +60,7 @@
     {:accept :json, :as :json, :form-params { :grant_type "password", :scope "basic" :username "bob" :password "my password"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true}
     (token-request { :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :username "bob" :password "my password" :insecure? true })))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client_id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client_id "CLIENT-ID" :client_secret "SECRET" :redirect_uri "http://test.com/callback" :code "CODE"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }
     (token-request { :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback" :insecure? true})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH"}, :basic-auth ["CLIENT-ID" "SECRET"], :insecure? true }

--- a/test/oauthentic/test/services/github.clj
+++ b/test/oauthentic/test/services/github.clj
@@ -15,7 +15,7 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"} }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"}, :insecure? false }
     (oauth/token-request { :service :github :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"}))))
 
 (defn github-request [{ :keys [params] :as req }]

--- a/test/oauthentic/test/services/github.clj
+++ b/test/oauthentic/test/services/github.clj
@@ -15,7 +15,7 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"}, :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"}, :insecure? false }
     (oauth/token-request { :service :github :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :redirect-uri "http://test.com/callback"}))))
 
 (defn github-request [{ :keys [params] :as req }]

--- a/test/oauthentic/test/services/github.clj
+++ b/test/oauthentic/test/services/github.clj
@@ -15,8 +15,8 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"}, :insecure? false }
-    (oauth/token-request { :service :github :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"}))))
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"}, :insecure? false }
+    (oauth/token-request { :service :github :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :redirect-uri "http://test.com/callback"}))))
 
 (defn github-request [{ :keys [params] :as req }]
   (if (and (= "SECRET" (:client_secret params)) (= "CLIENT" (:client_id params)))

--- a/test/oauthentic/test/services/stripe.clj
+++ b/test/oauthentic/test/services/stripe.clj
@@ -15,7 +15,7 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
     (oauth/token-request { :service :stripe :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }

--- a/test/oauthentic/test/services/stripe.clj
+++ b/test/oauthentic/test/services/stripe.clj
@@ -15,10 +15,10 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET" }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
     (oauth/token-request { :service :stripe :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH" :client_id "CLIENT-ID"}, :oauth-token "SECRET" }
+    {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
     (oauth/token-request { :service :stripe :refresh-token "REFRESH" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic"}))))
 
 (defn stripe-request [{ :keys [headers params] :as req }]

--- a/test/oauthentic/test/services/stripe.clj
+++ b/test/oauthentic/test/services/stripe.clj
@@ -15,7 +15,7 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID" :client_secret "SECRET"}, :oauth-token "SECRET", :insecure? false }
     (oauth/token-request { :service :stripe :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }

--- a/test/oauthentic/test/services/stripe.clj
+++ b/test/oauthentic/test/services/stripe.clj
@@ -15,7 +15,7 @@
 
 (deftest token-requests
   (is (=
-    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :client-id "CLIENT-ID" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
+    {:accept :json, :as :json, :form-params { :grant_type "authorization_code", :scope "basic" :redirect_uri "http://test.com/callback" :code "CODE" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }
     (oauth/token-request { :service :stripe :code "CODE" :client-id "CLIENT-ID" :client-secret "SECRET" :scope "basic" :redirect-uri "http://test.com/callback"})))
   (is (=
     {:accept :json, :as :json, :form-params { :grant_type "refresh_token", :scope "basic" :refresh_token "REFRESH" :client_id "CLIENT-ID"}, :oauth-token "SECRET", :insecure? false }


### PR DESCRIPTION
Update the token retrieval process for compatibility with the released OAuth2 specification (RFC6749) http://tools.ietf.org/html/rfc6749

Includes full tests, and has been tested with Github, and other OAuth providers. Should also work with Stripe service definition.
